### PR TITLE
Fixing getSettings method to support domains & sites in the trusted_host_patterns array. Updating change log.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Updates should follow the [Keep a CHANGELOG](https://keepachangelog.com/) princi
 
 ## [Unreleased][unreleased]
 
+## [0.2.1] - 2022-03-30
+
+### Fixed
+
+- Fixed construction of `trusted_host_patterns` array to support sites defined in the `SITES` constant.
+
 ## [0.2.0] - 2022-03-14
 
 ### Changed
@@ -135,7 +141,8 @@ Updates should follow the [Keep a CHANGELOG](https://keepachangelog.com/) princi
 
 **Initial release!**
 
-[unreleased]: https://github.com/unleashedtech/dotenv-drupal/compare/0.2.0...main
+[unreleased]: https://github.com/unleashedtech/dotenv-drupal/compare/0.2.1...main
+[0.2.1]: https://github.com/unleashedtech/dotenv-drupal/compare/0.2.0...0.2.1
 [0.2.0]: https://github.com/unleashedtech/dotenv-drupal/compare/0.1.17...0.2.0
 [0.1.17]: https://github.com/unleashedtech/dotenv-drupal/compare/0.1.16...0.1.17
 [0.1.16]: https://github.com/unleashedtech/dotenv-drupal/compare/0.1.15...0.1.16

--- a/README.md
+++ b/README.md
@@ -244,11 +244,30 @@ so the shorter DSN can be used.
 Streamlined environment-dependent configuration of _one_ Solr core is supported at this time.
 
 #### TRUSTED_HOST_PATTERNS
-Optional. A CSV list of patterns specifying [trusted hosts](https://www.drupal.org/docs/installing-drupal/trusted-host-settings#s-protecting-in-drupal-8). If this
-variable is not set, this package will populate Drupal's `trusted_host_patterns` array
-based on the value of [DOMAINS](#domains).
+Optional. A CSV list of patterns specifying [trusted hosts](https://www.drupal.org/docs/installing-drupal/trusted-host-settings#s-protecting-in-drupal-8).
 
 Start (`^`) & end (`$`) characters are added to every pattern, by default.
+
+##### Fallback Functionality
+If the `TRUSTED_HOST_PATTERNS` variable is _not_ set, this package will populate
+Drupal's `trusted_host_patterns` array based on the values of [DOMAINS](#domains)
+& [SITES](#sites) variables.
+
+###### Examples
+If you have `DOMAINS` set to `foo.example,bar.example`, the Drupal `trusted_host_patterns`
+settings array would have the following values:
+
+* `^foo\.example$`
+* `^www\.foo\.example$`
+* `^bar\.example$`
+* `^www\.bar\.example$`
+
+If you have `DOMAINS` set to `foo.example` & `SITES` set to `bar,baz,qux`, the
+Drupal `trusted_host_patterns` setting array would have the following values:
+
+* `^bar\.foo\.example$`
+* `^baz\.foo\.example$`
+* `^qux\.foo\.example$`
 
 #### Configuration Conclusion
 With these few Environment Variables, you will be able to configure Drupal in a streamlined

--- a/src/Dotenv.php
+++ b/src/Dotenv.php
@@ -287,6 +287,9 @@ class Dotenv
         if (isset($_SERVER['HASH_SALT'])) {
             $settings['hash_salt'] = $_SERVER['HASH_SALT'];
         }
+
+        // Configure trusted host patterns.
+        $settings['trusted_host_patterns'] = [];
         if (isset($_SERVER['TRUSTED_HOST_PATTERNS'])) {
             foreach (explode(',', $_SERVER['TRUSTED_HOST_PATTERNS']) as $pattern) {
                 $settings['trusted_host_patterns'][] = '^' . $pattern . '$';
@@ -295,6 +298,12 @@ class Dotenv
         else {
             foreach ($this->getDomains() as $domain) {
                 $settings['trusted_host_patterns'][] = '^' . str_replace('.', '\.', $domain) . '$';
+                foreach ($this->getSites() as $site) {
+                    $settings['trusted_host_patterns'][] = \vsprintf('^%s\.%s$', [
+                        $site === 'default' ? 'www' : $site,
+                        str_replace('.', '\.', $domain),
+                    ]);
+                }
             }
         }
 

--- a/src/Dotenv.php
+++ b/src/Dotenv.php
@@ -303,16 +303,19 @@ class Dotenv
         }
         else {
             foreach ($this->getDomains() as $domain) {
-                if (!$this->isMultiSite() || $this->isMultiSiteDefaultSiteAllowed()) {
-                    $settings['trusted_host_patterns'][] = '^' . str_replace('.', '\.', $domain) . '$';
+                if (! $this->isMultiSite() || $this->isMultiSiteDefaultSiteAllowed()) {
+                    $settings['trusted_host_patterns'][] = '^' . \str_replace('.', '\.', $domain) . '$';
+                    $settings['trusted_host_patterns'][] = '^www\.' . \str_replace('.', '\.', $domain) . '$';
                 }
+
                 foreach ($this->getSites() as $site) {
-                    if ($site === 'default' && !$this->isMultiSiteDefaultSiteAllowed()) {
+                    if ($site === 'default') {
                         continue;
                     }
+
                     $settings['trusted_host_patterns'][] = \vsprintf('^%s\.%s$', [
-                        $site === 'default' ? 'www' : $site,
-                        str_replace('.', '\.', $domain),
+                        $site,
+                        \str_replace('.', '\.', $domain),
                     ]);
                 }
             }


### PR DESCRIPTION
### Fixed

- Fixed construction of `trusted_host_patterns` array to support sites defined in the `SITES` constant.